### PR TITLE
A native bat file using cygwin head command

### DIFF
--- a/run-test-and-save-cygwin.bat
+++ b/run-test-and-save-cygwin.bat
@@ -1,0 +1,5 @@
+ctest -D ExperimentalTest --no-compress-output
+
+:: head is a cygwin utility
+FOR /f %%I IN ('head -n 1 Testing/TAG') DO SET DIR=%%I
+COPY Testing\%DIR%\Test.xml CTestResults.xml


### PR DESCRIPTION
Many don't use PowerShell but instead rely on Cygwin. 
In this file, all are Windows batch commands, except for the `head` utility from Cygwin.  
